### PR TITLE
[#37] instagram data paging 구현

### DIFF
--- a/core/network/src/main/java/com/example/network/service/GraphInstagramApiServiceSourceImpl.kt
+++ b/core/network/src/main/java/com/example/network/service/GraphInstagramApiServiceSourceImpl.kt
@@ -9,7 +9,7 @@ import retrofit2.http.Query
 
 interface GraphInstagramApiServiceSourceImpl : GraphInstagramApiServiceSource {
     @GET("/me/media?fields=id,caption,media_url")
-    override suspend fun getBoardInformation(@Query("access_token") accessToken: String): BoardDTO
+    override suspend fun getBoardInformation(@Query("access_token") accessToken: String, @Query("after") after: String?): BoardDTO
 
     @GET("/{mediaId}/children?fields=media_url")
     override suspend fun getBoardChildInformation(@Path("mediaId") mediaId: String, @Query("access_token") accessToken: String): BoardDetailDTO

--- a/core/room/build.gradle.kts
+++ b/core/room/build.gradle.kts
@@ -24,7 +24,9 @@ dependencies {
     implementation(libs.room.ktx)
     annotationProcessor(libs.room.compiler)
     ksp(libs.room.compiler)
+    implementation(libs.room.paging)
     implementation(libs.retrofit.gson)
+    implementation(libs.paging.common)
 
     implementation(project(":data:datasource"))
     implementation(project(":domain:model"))

--- a/core/room/src/main/java/com/example/room/BoardLocalDataSourceImpl.kt
+++ b/core/room/src/main/java/com/example/room/BoardLocalDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.example.room
 
+import androidx.paging.PagingSource
 import com.example.datasource.BoardLocalDataSource
 import com.example.model.Board
 import com.example.room.dao.BoardDao
@@ -32,6 +33,10 @@ class BoardLocalDataSourceImpl @Inject constructor(
 
     override suspend fun delete(boardItem: Board.Item) {
         boardDao.deleteBoard(BoardEntity(boardItem.id, boardItem.caption, boardItem.mediaUrl, boardItem.order))
+    }
+
+    override fun pagingSource(): PagingSource<Int, Board.Item> {
+        return boardDao.pagingSource()
     }
 
 }

--- a/core/room/src/main/java/com/example/room/dao/BoardDao.kt
+++ b/core/room/src/main/java/com/example/room/dao/BoardDao.kt
@@ -1,11 +1,13 @@
 package com.example.room.dao
 
+import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import com.example.model.Board
 import com.example.room.entity.BoardEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -26,4 +28,7 @@ interface BoardDao {
 
     @Delete
     suspend fun deleteBoard(boardEntity: BoardEntity)
+
+    @Query("Select * From BoardEntity ORDER BY `order` ASC")
+    fun pagingSource(): PagingSource<Int, Board.Item>
 }

--- a/core/room/src/main/java/com/example/room/entity/BoardEntity.kt
+++ b/core/room/src/main/java/com/example/room/entity/BoardEntity.kt
@@ -9,7 +9,7 @@ data class BoardEntity(
     @PrimaryKey
     val id: String,
     val caption: String? = "",
-    val mediaUrl: String,
+    val mediaUrl: String?,
     val order: Int = 0
 )
 

--- a/core/room/src/main/java/com/example/room/entity/BoardEntity.kt
+++ b/core/room/src/main/java/com/example/room/entity/BoardEntity.kt
@@ -8,7 +8,7 @@ import com.example.model.Board
 data class BoardEntity(
     @PrimaryKey
     val id: String,
-    val caption: String,
+    val caption: String? = "",
     val mediaUrl: String,
     val order: Int = 0
 )

--- a/data/datasource/build.gradle.kts
+++ b/data/datasource/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
 
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.java.inject)
+    implementation(libs.paging.common)
 
     implementation(project(":domain:model"))
     implementation(project(":data:dto"))

--- a/data/datasource/build.gradle.kts
+++ b/data/datasource/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.java.inject)
     implementation(libs.paging.common)
+    implementation(libs.retrofit.core)
 
     implementation(project(":domain:model"))
     implementation(project(":data:dto"))

--- a/data/datasource/src/main/java/com/example/datasource/BoardLocalDataSource.kt
+++ b/data/datasource/src/main/java/com/example/datasource/BoardLocalDataSource.kt
@@ -1,5 +1,6 @@
 package com.example.datasource
 
+import androidx.paging.PagingSource
 import com.example.model.Board
 
 interface BoardLocalDataSource {
@@ -11,4 +12,6 @@ interface BoardLocalDataSource {
     suspend fun update(board: Board)
 
     suspend fun delete(boardItem: Board.Item)
+
+    fun pagingSource(): PagingSource<Int, Board.Item>
 }

--- a/data/datasource/src/main/java/com/example/datasource/BoardPagingSource.kt
+++ b/data/datasource/src/main/java/com/example/datasource/BoardPagingSource.kt
@@ -29,7 +29,7 @@ class BoardPagingSource @Inject constructor(
             LoadResult.Page(
                 data = storedBoard,
                 prevKey = null,
-                nextKey =  boardDTO.paging.cursors.after
+                nextKey =  boardDTO.paging?.cursors?.after
             )
         } catch (e: Exception) {
             return LoadResult.Error(e)

--- a/data/datasource/src/main/java/com/example/datasource/BoardPagingSource.kt
+++ b/data/datasource/src/main/java/com/example/datasource/BoardPagingSource.kt
@@ -1,0 +1,35 @@
+package com.example.datasource
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.example.dto.toDomain
+import com.example.model.Board
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BoardPagingSource @Inject constructor(
+    private val graphInstagramApiServiceSource: GraphInstagramApiServiceSource,
+    private val accessToken: String
+    ) : PagingSource<String, Board.Item>() {
+    override fun getRefreshKey(state: PagingState<String, Board.Item>): String? {
+        return null
+    }
+
+    override suspend fun load(params: LoadParams<String>): LoadResult<String, Board.Item> {
+        val page = params.key
+
+        return try {
+            val boardDTO = graphInstagramApiServiceSource.getBoardInformation(accessToken, page)
+
+            LoadResult.Page(
+                data = boardDTO.toDomain().items,
+                prevKey = null,
+                nextKey =  boardDTO.paging.cursors.after
+            )
+        } catch (e: Exception) {
+            return LoadResult.Error(e)
+        }
+    }
+
+}

--- a/data/datasource/src/main/java/com/example/datasource/BoardPagingSource.kt
+++ b/data/datasource/src/main/java/com/example/datasource/BoardPagingSource.kt
@@ -10,8 +10,10 @@ import javax.inject.Singleton
 @Singleton
 class BoardPagingSource @Inject constructor(
     private val graphInstagramApiServiceSource: GraphInstagramApiServiceSource,
+    private val boardLocalDataSource: BoardLocalDataSource,
     private val accessToken: String
     ) : PagingSource<String, Board.Item>() {
+
     override fun getRefreshKey(state: PagingState<String, Board.Item>): String? {
         return null
     }
@@ -21,9 +23,11 @@ class BoardPagingSource @Inject constructor(
 
         return try {
             val boardDTO = graphInstagramApiServiceSource.getBoardInformation(accessToken, page)
+            boardLocalDataSource.insert(boardDTO.toDomain())
+            val storedBoard = boardLocalDataSource.select() ?: listOf()
 
             LoadResult.Page(
-                data = boardDTO.toDomain().items,
+                data = storedBoard,
                 prevKey = null,
                 nextKey =  boardDTO.paging.cursors.after
             )

--- a/data/datasource/src/main/java/com/example/datasource/BoardRemoteMediator.kt
+++ b/data/datasource/src/main/java/com/example/datasource/BoardRemoteMediator.kt
@@ -1,0 +1,45 @@
+package com.example.datasource
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import com.example.model.Board
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@OptIn(ExperimentalPagingApi::class)
+@Singleton
+class BoardRemoteMediator @Inject constructor(
+    private val graphInstagramApiServiceSource: GraphInstagramApiServiceSource,
+    private val boardLocalDataSource: BoardLocalDataSource,
+    private val accessToken: String
+) : RemoteMediator<Int, Board.Item>() {
+
+    private var afterKey: String? = null
+
+    override suspend fun load(
+        loadType: LoadType,
+        state: PagingState<Int, Board.Item>
+    ): MediatorResult {
+        return try {
+            val loadKey = when (loadType) {
+                LoadType.REFRESH -> null
+                LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
+                LoadType.APPEND -> {
+                    val key = afterKey ?: return MediatorResult.Success(endOfPaginationReached = true)
+                    key
+                }
+            }
+
+            val response = graphInstagramApiServiceSource.getBoardInformation(accessToken, loadKey)
+            afterKey = response.paging.cursors.after
+
+            boardLocalDataSource.insert(Board(response.items, response.paging))
+
+            MediatorResult.Success(endOfPaginationReached = response.paging.cursors.after.isEmpty())
+        } catch (e: Exception) {
+            MediatorResult.Error(e)
+        }
+    }
+}

--- a/data/datasource/src/main/java/com/example/datasource/BoardRemoteMediator.kt
+++ b/data/datasource/src/main/java/com/example/datasource/BoardRemoteMediator.kt
@@ -5,6 +5,8 @@ import androidx.paging.LoadType
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import com.example.model.Board
+import retrofit2.HttpException
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -33,12 +35,14 @@ class BoardRemoteMediator @Inject constructor(
             }
 
             val response = graphInstagramApiServiceSource.getBoardInformation(accessToken, loadKey)
-            afterKey = response.paging.cursors.after
+            afterKey = response.paging?.cursors?.after
 
             boardLocalDataSource.insert(Board(response.items, response.paging))
 
-            MediatorResult.Success(endOfPaginationReached = response.paging.cursors.after.isEmpty())
-        } catch (e: Exception) {
+            MediatorResult.Success(endOfPaginationReached = response.paging?.cursors?.after.isNullOrEmpty())
+        } catch (e: IOException) {
+            MediatorResult.Error(e)
+        } catch (e: HttpException) {
             MediatorResult.Error(e)
         }
     }

--- a/data/datasource/src/main/java/com/example/datasource/GraphInstagramApiServiceSource.kt
+++ b/data/datasource/src/main/java/com/example/datasource/GraphInstagramApiServiceSource.kt
@@ -4,6 +4,6 @@ import com.example.dto.BoardDTO
 import com.example.dto.BoardDetailDTO
 
 interface GraphInstagramApiServiceSource  {
-    suspend fun getBoardInformation(accessToken: String): BoardDTO
+    suspend fun getBoardInformation(accessToken: String, after: String?): BoardDTO
     suspend fun getBoardChildInformation(mediaId: String, accessToken: String): BoardDetailDTO
 }

--- a/data/dto/src/main/java/com/example/dto/BoardDTO.kt
+++ b/data/dto/src/main/java/com/example/dto/BoardDTO.kt
@@ -5,8 +5,10 @@ import com.google.gson.annotations.SerializedName
 
 data class BoardDTO(
     @SerializedName("data")
-    val items: ArrayList<Board.Item>
+    val items: ArrayList<Board.Item>,
+    val paging: Board.Paging
 )
+
 fun BoardDTO.toDomain(): Board {
-    return Board(items)
+    return Board(items, paging)
 }

--- a/data/dto/src/main/java/com/example/dto/BoardDTO.kt
+++ b/data/dto/src/main/java/com/example/dto/BoardDTO.kt
@@ -6,7 +6,7 @@ import com.google.gson.annotations.SerializedName
 data class BoardDTO(
     @SerializedName("data")
     val items: List<Board.Item>,
-    val paging: Board.Paging
+    val paging: Board.Paging?
 )
 
 fun BoardDTO.toDomain(): Board {

--- a/data/dto/src/main/java/com/example/dto/BoardDTO.kt
+++ b/data/dto/src/main/java/com/example/dto/BoardDTO.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName
 
 data class BoardDTO(
     @SerializedName("data")
-    val items: ArrayList<Board.Item>,
+    val items: List<Board.Item>,
     val paging: Board.Paging
 )
 

--- a/data/repository/build.gradle.kts
+++ b/data/repository/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.java.inject)
+    implementation(libs.paging.common)
 
     implementation(project(":domain:repository"))
     implementation(project(":domain:model"))

--- a/data/repository/src/main/java/com/example/repository/remote/InstagramRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/example/repository/remote/InstagramRepositoryImpl.kt
@@ -1,14 +1,13 @@
 package com.example.repository.remote
 
+import androidx.paging.ExperimentalPagingApi
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
-import androidx.paging.PagingData
 import com.example.datasource.BoardLocalDataSource
-import com.example.datasource.BoardPagingSource
+import com.example.datasource.BoardRemoteMediator
 import com.example.datasource.GraphInstagramApiServiceSource
 import com.example.datasource.InstagramLoginDataSource
 import com.example.dto.toDomain
-import com.example.model.Board
 import com.example.model.Login
 import com.example.model.Token
 import com.example.repository.InstagramRepository
@@ -38,10 +37,13 @@ class InstagramRepositoryImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override fun fetchBoardInformation(accessToken: String, after: String?): Flow<PagingData<Board.Item>> =
+    @OptIn(ExperimentalPagingApi::class)
+    override fun fetchBoardInformation(accessToken: String, after: String?) =
         Pager(
-            config = PagingConfig(pageSize = 5),
-            pagingSourceFactory = { BoardPagingSource(graphInstagramApiServiceSource, boardLocalDataSource, accessToken) }
-        ).flow
+            config = PagingConfig(pageSize = 25, enablePlaceholders = false),
+            remoteMediator = BoardRemoteMediator(graphInstagramApiServiceSource, boardLocalDataSource, accessToken)
+        ) {
+            boardLocalDataSource.pagingSource()
+        }.flow
 
 }

--- a/data/repository/src/main/java/com/example/repository/remote/InstagramRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/example/repository/remote/InstagramRepositoryImpl.kt
@@ -37,13 +37,13 @@ class InstagramRepositoryImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    @OptIn(ExperimentalPagingApi::class)
+
+  @OptIn(ExperimentalPagingApi::class)
     override fun fetchBoardInformation(accessToken: String, after: String?) =
         Pager(
             config = PagingConfig(pageSize = 25, enablePlaceholders = false),
-            remoteMediator = BoardRemoteMediator(graphInstagramApiServiceSource, boardLocalDataSource, accessToken)
-        ) {
-            boardLocalDataSource.pagingSource()
-        }.flow
+            remoteMediator = BoardRemoteMediator(graphInstagramApiServiceSource, boardLocalDataSource, accessToken),
+            pagingSourceFactory = boardLocalDataSource::pagingSource
+        ).flow
 
 }

--- a/data/repository/src/main/java/com/example/repository/remote/InstagramRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/example/repository/remote/InstagramRepositoryImpl.kt
@@ -1,5 +1,9 @@
 package com.example.repository.remote
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.example.datasource.BoardPagingSource
 import com.example.datasource.GraphInstagramApiServiceSource
 import com.example.datasource.InstagramLoginDataSource
 import com.example.dto.toDomain
@@ -32,8 +36,10 @@ class InstagramRepositoryImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override fun fetchBoardInformation(accessToken: String): Flow<Board> = flow {
-        emit(graphInstagramApiServiceSource.getBoardInformation(accessToken).toDomain())
-    }.flowOn(Dispatchers.IO)
+    override fun fetchBoardInformation(accessToken: String, after: String?): Flow<PagingData<Board.Item>> =
+        Pager(
+            config = PagingConfig(pageSize = 20),
+            pagingSourceFactory = { BoardPagingSource(graphInstagramApiServiceSource, accessToken) }
+        ).flow
 
 }

--- a/data/repository/src/main/java/com/example/repository/remote/InstagramRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/example/repository/remote/InstagramRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.example.repository.remote
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import com.example.datasource.BoardLocalDataSource
 import com.example.datasource.BoardPagingSource
 import com.example.datasource.GraphInstagramApiServiceSource
 import com.example.datasource.InstagramLoginDataSource
@@ -21,7 +22,8 @@ import javax.inject.Singleton
 @Singleton
 class InstagramRepositoryImpl @Inject constructor(
     private val instagramLoginDataSource: InstagramLoginDataSource,
-    private val graphInstagramApiServiceSource: GraphInstagramApiServiceSource
+    private val graphInstagramApiServiceSource: GraphInstagramApiServiceSource,
+    private val boardLocalDataSource: BoardLocalDataSource,
 ) : InstagramRepository {
 
     override fun fetchToken(login: Login): Flow<Token> = flow {
@@ -38,8 +40,8 @@ class InstagramRepositoryImpl @Inject constructor(
 
     override fun fetchBoardInformation(accessToken: String, after: String?): Flow<PagingData<Board.Item>> =
         Pager(
-            config = PagingConfig(pageSize = 20),
-            pagingSourceFactory = { BoardPagingSource(graphInstagramApiServiceSource, accessToken) }
+            config = PagingConfig(pageSize = 5),
+            pagingSourceFactory = { BoardPagingSource(graphInstagramApiServiceSource, boardLocalDataSource, accessToken) }
         ).flow
 
 }

--- a/domain/model/src/main/java/com/example/model/Board.kt
+++ b/domain/model/src/main/java/com/example/model/Board.kt
@@ -8,7 +8,7 @@ data class Board(
 ) {
     data class Item(
         val id: String,
-        val caption: String,
+        val caption: String?,
         @SerializedName("media_url")
         val mediaUrl: String,
         var order: Int = 0

--- a/domain/model/src/main/java/com/example/model/Board.kt
+++ b/domain/model/src/main/java/com/example/model/Board.kt
@@ -3,7 +3,8 @@ package com.example.model
 import com.google.gson.annotations.SerializedName
 
 data class Board(
-    val items: List<Item>
+    val items: List<Item>,
+    val paging: Paging?
 ) {
     data class Item(
         val id: String,
@@ -12,5 +13,15 @@ data class Board(
         val mediaUrl: String,
         var order: Int = 0
     )
+
+    data class Paging(
+        val cursors: Cursors,
+        val next: String
+    ) {
+        data class Cursors(
+            val before: String,
+            val after: String
+        )
+    }
 }
 

--- a/domain/model/src/main/java/com/example/model/Board.kt
+++ b/domain/model/src/main/java/com/example/model/Board.kt
@@ -10,17 +10,17 @@ data class Board(
         val id: String,
         val caption: String?,
         @SerializedName("media_url")
-        val mediaUrl: String,
+        val mediaUrl: String?,
         var order: Int = 0
     )
 
     data class Paging(
-        val cursors: Cursors,
-        val next: String
+        val cursors: Cursors?,
+        val next: String?
     ) {
         data class Cursors(
-            val before: String,
-            val after: String
+            val before: String?,
+            val after: String?
         )
     }
 }

--- a/domain/repository/build.gradle.kts
+++ b/domain/repository/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.java.inject)
+    implementation(libs.paging.common)
 
     implementation(project(":domain:model"))
 }

--- a/domain/repository/src/main/java/com/example/repository/InstagramRepository.kt
+++ b/domain/repository/src/main/java/com/example/repository/InstagramRepository.kt
@@ -1,5 +1,6 @@
 package com.example.repository
 
+import androidx.paging.PagingData
 import com.example.model.Board
 import com.example.model.Login
 import com.example.model.Token
@@ -23,8 +24,9 @@ interface InstagramRepository {
     fun fetchToken(login: Login): Flow<Token>
 
     fun fetchBoardInformation(
-        accessToken: String
-    ): Flow<Board>
-    
+        accessToken: String,
+        after: String?
+    ): Flow<PagingData<Board.Item>>
+
 }
 

--- a/domain/usecase/build.gradle.kts
+++ b/domain/usecase/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation(libs.java.inject)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.paging.common)
 
     implementation(project(":domain:repository"))
     implementation(project(":domain:model"))

--- a/domain/usecase/src/main/java/com/example/usecase/FetchInstagramBoardUseCase.kt
+++ b/domain/usecase/src/main/java/com/example/usecase/FetchInstagramBoardUseCase.kt
@@ -1,14 +1,15 @@
 package com.example.usecase
 
+import androidx.paging.PagingData
 import com.example.model.Board
 import com.example.repository.InstagramRepository
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class FetchInstagramBoardUseCase @Inject constructor(private val instagramRepository: InstagramRepository) {
-    suspend operator fun invoke(accessToken: String): Board? {
-         return instagramRepository.fetchBoardInformation(accessToken).firstOrNull()
+     operator fun invoke(accessToken: String, after: String? = null): Flow<PagingData<Board.Item>> {
+         return instagramRepository.fetchBoardInformation(accessToken, after)
     }
 }

--- a/feature/board/build.gradle.kts
+++ b/feature/board/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     implementation(libs.swipeRefreshLayout)
     testImplementation(libs.bundles.kotest)
     testImplementation(libs.mockk)
+    implementation(libs.paging.runtime)
+
     implementation(project(":domain:usecase"))
     implementation(project(":domain:model"))
 }

--- a/feature/board/src/main/java/com/example/board/ItemMoveCallback.kt
+++ b/feature/board/src/main/java/com/example/board/ItemMoveCallback.kt
@@ -28,7 +28,7 @@ class ItemMoveCallback(
         viewHolder: RecyclerView.ViewHolder,
         target: RecyclerView.ViewHolder
     ): Boolean {
-//        onCompleteListener(boardAdapter.onItemMove(viewHolder.bindingAdapterPosition, target.bindingAdapterPosition))
+        onCompleteListener(boardAdapter.onItemMove(viewHolder.bindingAdapterPosition, target.bindingAdapterPosition))
         return true
     }
 

--- a/feature/board/src/main/java/com/example/board/ItemMoveCallback.kt
+++ b/feature/board/src/main/java/com/example/board/ItemMoveCallback.kt
@@ -28,7 +28,7 @@ class ItemMoveCallback(
         viewHolder: RecyclerView.ViewHolder,
         target: RecyclerView.ViewHolder
     ): Boolean {
-//        onCompleteListener(boardAdapter.onItemMove(viewHolder.adapterPosition, target.adapterPosition))
+//        onCompleteListener(boardAdapter.onItemMove(viewHolder.bindingAdapterPosition, target.bindingAdapterPosition))
         return true
     }
 

--- a/feature/board/src/main/java/com/example/board/ItemMoveCallback.kt
+++ b/feature/board/src/main/java/com/example/board/ItemMoveCallback.kt
@@ -28,7 +28,7 @@ class ItemMoveCallback(
         viewHolder: RecyclerView.ViewHolder,
         target: RecyclerView.ViewHolder
     ): Boolean {
-        onCompleteListener(boardAdapter.onItemMove(viewHolder.adapterPosition, target.adapterPosition))
+//        onCompleteListener(boardAdapter.onItemMove(viewHolder.adapterPosition, target.adapterPosition))
         return true
     }
 

--- a/feature/board/src/main/java/com/example/board/adapter/BoardAdapter.kt
+++ b/feature/board/src/main/java/com/example/board/adapter/BoardAdapter.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
 @FragmentScoped
 class BoardAdapter @Inject constructor(): PagingDataAdapter<Board.Item, BoardAdapter.FeedHolder>(DiffFeed) {
 
-    private var onItemClick: ((Board.Item) -> Unit)? = null
+    private var onItemClick: ((Board.Item, Int) -> Unit)? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FeedHolder =
         FeedHolder(HolderFeedItemBinding.inflate(LayoutInflater.from(parent.context), parent, false))
@@ -25,7 +25,7 @@ class BoardAdapter @Inject constructor(): PagingDataAdapter<Board.Item, BoardAda
         getItem(position)?.let { holder.bind(it, onItemClick) }
     }
 
-    fun setOnItemClickListener(listener: (Board.Item) -> Unit) {
+    fun setOnItemClickListener(listener: (Board.Item, Int) -> Unit) {
         onItemClick = listener
     }
 
@@ -34,7 +34,7 @@ class BoardAdapter @Inject constructor(): PagingDataAdapter<Board.Item, BoardAda
 
         fun bind(
             boardInformation: Board.Item,
-            onItemClick: ((Board.Item) -> Unit)?,
+            onItemClick: ((Board.Item, Int) -> Unit)?,
         ) {
             currentItem = boardInformation
             binding.root.tag = false
@@ -44,7 +44,7 @@ class BoardAdapter @Inject constructor(): PagingDataAdapter<Board.Item, BoardAda
                 DiskCacheStrategy.ALL).into(binding.feedImageview)
 
             binding.root.setOnClickListener {
-                onItemClick?.let { it -> it(boardInformation) }
+                onItemClick?.let { it -> it(boardInformation, bindingAdapterPosition) }
             }
 
         }

--- a/feature/board/src/main/java/com/example/board/adapter/BoardAdapter.kt
+++ b/feature/board/src/main/java/com/example/board/adapter/BoardAdapter.kt
@@ -14,9 +14,7 @@ import dagger.hilt.android.scopes.FragmentScoped
 import javax.inject.Inject
 
 @FragmentScoped
-class BoardAdapter @Inject constructor(): PagingDataAdapter<Board.Item, BoardAdapter.FeedHolder>(
-    DiffFeed
-) {
+class BoardAdapter @Inject constructor(): PagingDataAdapter<Board.Item, BoardAdapter.FeedHolder>(DiffFeed) {
 
     private var onItemClick: ((Board.Item) -> Unit)? = null
 

--- a/feature/board/src/main/java/com/example/board/adapter/BoardAdapter.kt
+++ b/feature/board/src/main/java/com/example/board/adapter/BoardAdapter.kt
@@ -30,13 +30,11 @@ class BoardAdapter @Inject constructor(): PagingDataAdapter<Board.Item, BoardAda
     }
 
     class FeedHolder(private val binding: HolderFeedItemBinding) : RecyclerView.ViewHolder(binding.root) {
-        var currentItem: Board.Item? = null
 
         fun bind(
             boardInformation: Board.Item,
             onItemClick: ((Board.Item, Int) -> Unit)?,
         ) {
-            currentItem = boardInformation
             binding.root.tag = false
             Glide.with(binding.feedImageview).load(boardInformation.mediaUrl).error(R.drawable.no_image).placeholder(
                 R.drawable.no_image
@@ -61,23 +59,27 @@ class BoardAdapter @Inject constructor(): PagingDataAdapter<Board.Item, BoardAda
 
     }
 
-//    fun onItemMove(fromPosition: Int, toPosition: Int): List<Board.Item> {
-//        val updatedList = currentList.toMutableList()
-//        updatedList.swap(fromPosition, toPosition)
-//
-//        submitList(updatedList)
-//
-//        return listOf(updatedList[fromPosition], updatedList[toPosition])
-//    }
+    fun onItemMove(fromPosition: Int, toPosition: Int): List<Board.Item> {
+        val items = arrayListOf<Board.Item>()
 
-    private fun MutableList<Board.Item>.swap(fromPosition: Int, toPosition: Int) {
-        val tmp = this[fromPosition]
-        this[fromPosition] = this[toPosition]
-        this[toPosition] = tmp
+        notifyItemMoved(toPosition, fromPosition)
 
-        val tmpOrder = this[fromPosition].order
-        this[fromPosition].order = this[toPosition].order
-        this[toPosition].order = tmpOrder
+        val beforeItem = getItem(fromPosition)
+        val afterItem = getItem(toPosition)
+
+        if (beforeItem != null && afterItem != null) {
+            items.add(beforeItem)
+            items.add(afterItem)
+
+            beforeItem.swapOrderWith(afterItem)
+        }
+        return items
+    }
+
+    private fun Board.Item.swapOrderWith(target: Board.Item) {
+        val tmpOrder = this.order
+        this.order = target.order
+        target.order = tmpOrder
     }
 
 }

--- a/feature/board/src/main/java/com/example/board/adapter/BoardAdapter.kt
+++ b/feature/board/src/main/java/com/example/board/adapter/BoardAdapter.kt
@@ -1,11 +1,9 @@
 package com.example.board.adapter
 
 import android.view.LayoutInflater
-import android.view.MotionEvent
 import android.view.ViewGroup
-import android.widget.ImageView
+import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -16,7 +14,7 @@ import dagger.hilt.android.scopes.FragmentScoped
 import javax.inject.Inject
 
 @FragmentScoped
-class BoardAdapter @Inject constructor(): ListAdapter<Board.Item, BoardAdapter.FeedHolder>(
+class BoardAdapter @Inject constructor(): PagingDataAdapter<Board.Item, BoardAdapter.FeedHolder>(
     DiffFeed
 ) {
 
@@ -26,7 +24,7 @@ class BoardAdapter @Inject constructor(): ListAdapter<Board.Item, BoardAdapter.F
         FeedHolder(HolderFeedItemBinding.inflate(LayoutInflater.from(parent.context), parent, false))
 
     override fun onBindViewHolder(holder: FeedHolder, position: Int) {
-        holder.bind(getItem(position), onItemClick)
+        getItem(position)?.let { holder.bind(it, onItemClick) }
     }
 
     fun setOnItemClickListener(listener: (Board.Item) -> Unit) {
@@ -65,14 +63,14 @@ class BoardAdapter @Inject constructor(): ListAdapter<Board.Item, BoardAdapter.F
 
     }
 
-    fun onItemMove(fromPosition: Int, toPosition: Int): List<Board.Item> {
-        val updatedList = currentList.toMutableList()
-        updatedList.swap(fromPosition, toPosition)
-
-        submitList(updatedList)
-
-        return listOf(updatedList[fromPosition], updatedList[toPosition])
-    }
+//    fun onItemMove(fromPosition: Int, toPosition: Int): List<Board.Item> {
+//        val updatedList = currentList.toMutableList()
+//        updatedList.swap(fromPosition, toPosition)
+//
+//        submitList(updatedList)
+//
+//        return listOf(updatedList[fromPosition], updatedList[toPosition])
+//    }
 
     private fun MutableList<Board.Item>.swap(fromPosition: Int, toPosition: Int) {
         val tmp = this[fromPosition]

--- a/feature/board/src/main/java/com/example/board/adapter/BoardLoadStateAdapter.kt
+++ b/feature/board/src/main/java/com/example/board/adapter/BoardLoadStateAdapter.kt
@@ -1,0 +1,45 @@
+package com.example.board.adapter
+
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.core.view.isVisible
+import androidx.paging.LoadState
+import androidx.paging.LoadStateAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.board.databinding.HolderLoadStateBinding
+
+class BoardLoadStateAdapter(private val retry: () -> Unit) : LoadStateAdapter<BoardLoadStateAdapter.LoadStateViewHolder>() {
+
+    override fun onBindViewHolder(holder: LoadStateViewHolder, loadState: LoadState) =
+         holder.bind(loadState)
+
+    override fun onCreateViewHolder(parent: ViewGroup, loadState: LoadState): LoadStateViewHolder {
+        val binding = HolderLoadStateBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return LoadStateViewHolder(binding)
+    }
+
+    inner class LoadStateViewHolder(
+        binding: HolderLoadStateBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+        private val progressBar: ProgressBar = binding.progressBar
+        private val errorMsg: TextView = binding.errorTextView
+        private val retry: Button = binding.retryButton.also {
+                it.setOnClickListener { retry() }
+            }
+
+        fun bind(loadState: LoadState) {
+            if (loadState is LoadState.Error) {
+                errorMsg.text = loadState.error.localizedMessage
+            }
+
+            progressBar.isVisible = loadState is LoadState.Loading
+            retry.isVisible = loadState is LoadState.Error
+            errorMsg.isVisible = loadState is LoadState.Error
+        }
+    }
+
+}

--- a/feature/board/src/main/java/com/example/board/view/BoardFragment.kt
+++ b/feature/board/src/main/java/com/example/board/view/BoardFragment.kt
@@ -3,14 +3,12 @@ package com.example.board.view
 import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.core.net.toUri
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -25,7 +23,6 @@ import com.example.board.ItemMoveCallback
 import com.example.board.R
 import com.example.board.adapter.BoardAdapter
 import com.example.board.databinding.FragmentBoardBinding
-import com.example.board.viewmodel.BoardUiState
 import com.example.board.viewmodel.BoardViewModel
 import com.example.model.Board
 import dagger.hilt.android.AndroidEntryPoint
@@ -42,19 +39,21 @@ class BoardFragment : Fragment(R.layout.fragment_board){
     lateinit var boardAdapter: BoardAdapter
     private var _binding: FragmentBoardBinding? = null
     private val binding get() = _binding!!
+    var token: String? = ""
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentBoardBinding.inflate(inflater,container, false)
+        _binding = FragmentBoardBinding.inflate(inflater, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val token = arguments?.getString("accessToken")
+        token = arguments?.getString("accessToken")
+
         initRecyclerView()
         requestBoardItems(token)
         initObserver()
@@ -87,7 +86,7 @@ class BoardFragment : Fragment(R.layout.fragment_board){
     }
 
     private fun requestBoardItems(token: String?) {
-        boardViewModel.requestBoardItem(token)
+//        boardViewModel.requestBoardItem(token)
     }
 
     private fun initRecyclerView() {
@@ -109,6 +108,7 @@ class BoardFragment : Fragment(R.layout.fragment_board){
 
                 }
             }
+
             layoutManager = GridLayoutManager(context, 3)
 
             val callback = ItemMoveCallback(
@@ -128,24 +128,32 @@ class BoardFragment : Fragment(R.layout.fragment_board){
     }
 
     private fun initObserver() {
+//        viewLifecycleOwner.lifecycleScope.launch {
+//            repeatOnLifecycle(Lifecycle.State.STARTED) {
+//                boardViewModel.boardUiState.collectLatest { state ->
+//                    when (state) {
+//                        is BoardUiState.Success -> {
+//                            binding.progressBar.isVisible = false
+//                            boardAdapter.submitData()
+//                        }
+//                        is BoardUiState.Error -> {
+//                            Log.d(TAG, "Error")
+//                            binding.progressBar.isVisible = false
+//                            Log.d(TAG, state.message)
+//                        }
+//                        is BoardUiState.Loading -> {
+//                            Log.d(TAG, "loading")
+//                            binding.progressBar.isVisible = true
+//                        }
+//                    }
+//                }
+//            }
+//        }
+
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                boardViewModel.boardUiState.collectLatest { state ->
-                    when (state) {
-                        is BoardUiState.Success -> {
-                            binding.progressBar.isVisible = false
-                            boardAdapter.submitList(state.data)
-                        }
-                        is BoardUiState.Error -> {
-                            Log.d(TAG, "Error")
-                            binding.progressBar.isVisible = false
-                            Log.d(TAG, state.message)
-                        }
-                        is BoardUiState.Loading -> {
-                            Log.d(TAG, "loading")
-                            binding.progressBar.isVisible = true
-                        }
-                    }
+                boardViewModel.requestBoardPagingItem(token).collectLatest {
+                    boardAdapter.submitData(it)
                 }
             }
         }

--- a/feature/board/src/main/java/com/example/board/view/BoardFragment.kt
+++ b/feature/board/src/main/java/com/example/board/view/BoardFragment.kt
@@ -39,7 +39,7 @@ class BoardFragment : Fragment(R.layout.fragment_board){
     lateinit var boardAdapter: BoardAdapter
     private var _binding: FragmentBoardBinding? = null
     private val binding get() = _binding!!
-    var token: String? = ""
+    private var token: String? = ""
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -55,7 +55,6 @@ class BoardFragment : Fragment(R.layout.fragment_board){
         token = arguments?.getString("accessToken")
 
         initRecyclerView()
-        requestBoardItems(token)
         initObserver()
         initSwipeRefreshLayout(token)
         initClickListener()
@@ -78,15 +77,11 @@ class BoardFragment : Fragment(R.layout.fragment_board){
         binding.swipeRefreshLayout.apply {
             setOnRefreshListener {
                 lifecycleScope.launchWhenCreated {
-                    requestBoardItems(token)
+
                 }
                 isRefreshing = false
             }
         }
-    }
-
-    private fun requestBoardItems(token: String?) {
-//        boardViewModel.requestBoardItem(token)
     }
 
     private fun initRecyclerView() {
@@ -128,31 +123,9 @@ class BoardFragment : Fragment(R.layout.fragment_board){
     }
 
     private fun initObserver() {
-//        viewLifecycleOwner.lifecycleScope.launch {
-//            repeatOnLifecycle(Lifecycle.State.STARTED) {
-//                boardViewModel.boardUiState.collectLatest { state ->
-//                    when (state) {
-//                        is BoardUiState.Success -> {
-//                            binding.progressBar.isVisible = false
-//                            boardAdapter.submitData()
-//                        }
-//                        is BoardUiState.Error -> {
-//                            Log.d(TAG, "Error")
-//                            binding.progressBar.isVisible = false
-//                            Log.d(TAG, state.message)
-//                        }
-//                        is BoardUiState.Loading -> {
-//                            Log.d(TAG, "loading")
-//                            binding.progressBar.isVisible = true
-//                        }
-//                    }
-//                }
-//            }
-//        }
-
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                boardViewModel.requestBoardPagingItem(token).collectLatest {
+                boardViewModel.requestBoardPagingItem(token)?.collectLatest {
                     boardAdapter.submitData(it)
                 }
             }

--- a/feature/board/src/main/java/com/example/board/view/BoardFragment.kt
+++ b/feature/board/src/main/java/com/example/board/view/BoardFragment.kt
@@ -76,8 +76,12 @@ class BoardFragment : Fragment(R.layout.fragment_board){
     private fun initSwipeRefreshLayout(token: String?) {
         binding.swipeRefreshLayout.apply {
             setOnRefreshListener {
-                lifecycleScope.launchWhenCreated {
-
+                viewLifecycleOwner.lifecycleScope.launch {
+                    repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        boardViewModel.requestBoardPagingItem(token)?.collectLatest {
+                            boardAdapter.submitData(it)
+                        }
+                    }
                 }
                 isRefreshing = false
             }
@@ -87,10 +91,11 @@ class BoardFragment : Fragment(R.layout.fragment_board){
     private fun initRecyclerView() {
         with (binding.feedRecyclerView) {
             adapter = boardAdapter.apply {
-                setOnItemClickListener { board ->
+                setOnItemClickListener { board, position ->
                     when (binding.trashCanImageView.tag) {
                         true -> {
                             boardViewModel.requestBoardItemDeleteAndSelect(board)
+                            boardAdapter.notifyItemRemoved(position)
                         }
                         else -> {
                             boardViewModel.requestBoardChildItems(board.id)

--- a/feature/board/src/main/java/com/example/board/view/BoardFragment.kt
+++ b/feature/board/src/main/java/com/example/board/view/BoardFragment.kt
@@ -114,7 +114,7 @@ class BoardFragment : Fragment(R.layout.fragment_board){
             val callback = ItemMoveCallback(
                 boardAdapter = boardAdapter,
                 onCompleteListener = {
-                    boardViewModel.requestBoardItemUpdate(Board(it))
+                    boardViewModel.requestBoardItemUpdate(Board(it, null))
                 },
                 onSelectedChangedListener = {
                     binding.swipeRefreshLayout.isEnabled = binding.swipeRefreshLayout.isEnabled.not()

--- a/feature/board/src/main/java/com/example/board/view/BoardFragment.kt
+++ b/feature/board/src/main/java/com/example/board/view/BoardFragment.kt
@@ -22,6 +22,7 @@ import com.example.board.GridDividerItemDecoration
 import com.example.board.ItemMoveCallback
 import com.example.board.R
 import com.example.board.adapter.BoardAdapter
+import com.example.board.adapter.BoardLoadStateAdapter
 import com.example.board.databinding.FragmentBoardBinding
 import com.example.board.viewmodel.BoardViewModel
 import com.example.model.Board
@@ -91,6 +92,7 @@ class BoardFragment : Fragment(R.layout.fragment_board){
     private fun initRecyclerView() {
         with (binding.feedRecyclerView) {
             adapter = boardAdapter.apply {
+
                 setOnItemClickListener { board, position ->
                     when (binding.trashCanImageView.tag) {
                         true -> {
@@ -108,6 +110,7 @@ class BoardFragment : Fragment(R.layout.fragment_board){
 
                 }
             }
+            adapter = boardAdapter.withLoadStateFooter(BoardLoadStateAdapter(boardAdapter::retry))
 
             layoutManager = GridLayoutManager(context, 3)
 

--- a/feature/board/src/main/java/com/example/board/viewmodel/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/example/board/viewmodel/BoardViewModel.kt
@@ -36,39 +36,9 @@ class BoardViewModel @Inject constructor(
     private val _boardDetailUiState = MutableStateFlow<BoardDetailUiState<BoardDetail>>(BoardDetailUiState.Loading)
     val boardDetailUiState = _boardDetailUiState.asStateFlow()
 
-    fun requestBoardPagingItem(token: String?): Flow<PagingData<Board.Item>> {
-       return fetchInstagramBoardUseCase.invoke(token!!).cachedIn(viewModelScope)
+    fun requestBoardPagingItem(token: String?): Flow<PagingData<Board.Item>>? {
+        return token?.let { fetchInstagramBoardUseCase.invoke(it).cachedIn(viewModelScope) }
     }
-
-//    fun requestBoardItem(token: String?) = viewModelScope.launch {
-//        token.also { accessToken ->
-//            if (!accessToken.isNullOrBlank()) {
-//                runCatching {
-//                    fetchInstagramBoardUseCase.invoke(accessToken)
-//                }.onFailure {
-//                    _boardUiState.value = BoardUiState.Error("board fetch Error!!")
-//                }.onSuccess { board ->
-//                    if (board != null) {
-////                        requestBoardItemInsert(board)
-//                        _boardUiState.value = BoardUiState.Success(board)
-//                    } else {
-//                        _boardUiState.value = BoardUiState.Error("board is nullOrEmpty")
-//                    }
-//                }
-//            } else {
-//                _boardUiState.value = BoardUiState.Error("accessToken is nullOrEmpty")
-//            }
-//        }
-////        val boardAll = requestBoardItemsFind()
-//        when {
-////            !boardAll.isNullOrEmpty() -> {
-////                _boardUiState.value = BoardUiState.Success(boardAll)
-////            }
-//            else -> {
-//
-//            }
-//        }
-//    }
 
     fun requestBoardChildItems(mediaId: String) = viewModelScope.launch {
         manageUserInformationUseCase.get().also { accessToken ->

--- a/feature/board/src/main/java/com/example/board/viewmodel/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/example/board/viewmodel/BoardViewModel.kt
@@ -67,7 +67,7 @@ class BoardViewModel @Inject constructor(
         updateBoardUseCase.invoke(board)
     }
 
-    private suspend fun requestBoardItemsFind(): List<Board.Item>? {
+    suspend fun requestBoardItemsFind(): List<Board.Item>? {
         return findBoardUseCase.invoke()
     }
 

--- a/feature/board/src/main/res/layout/holder_load_state.xml
+++ b/feature/board/src/main/res/layout/holder_load_state.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <Button
+        android:id="@+id/retryButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/progressBar"
+        android:text="retry"/>
+
+    <TextView
+        android:id="@+id/errorTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/retryButton"
+        android:text="데이터 로드 실패"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -141,6 +141,7 @@ retrofit-kotlin-serialization = { group = "com.jakewharton.retrofit", name = "re
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+room-paging = { group = "androidx.room", name = "room-paging", version.ref = "room"}
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 android-material = {group = "com.google.android.material", name = "material", version.ref = "material"}
 androidx-constraintLayout = {group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintLayout"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ org-jetbrains-kotlin-android = "1.8.0"
 kotest = "5.7.2"
 mockk = "1.13.4"
 java-inject = "1"
-
+paging = "3.1.1"
 [libraries]
 accompanist-flowlayout = { group = "com.google.accompanist", name = "accompanist-flowlayout", version.ref = "accompanist" }
 accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version.ref = "accompanist" }
@@ -151,6 +151,8 @@ android-junit = {group = "androidx.test.ext", name = "junit", version.ref = "jun
 glide = {group = "com.github.bumptech.glide", name = "glide", version.ref = "glide"}
 swipeRefreshLayout = {group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "swipeRefreshLayout"}
 java-inject = { group = "javax.inject", name = "javax.inject", version.ref = "java-inject" }
+paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging"}
+paging-common = { group = "androidx.paging", name = "paging-common-ktx", version.ref = "paging" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
instagram data paging 구현의 건

### 요구사항
인스타그램 데이터의 Paging을 지원하고 Paging3의 RemoteMediator를 사용해 Local DB인 Room에 저장한다.
RemoteMediator 를 사용함으로 오프라인에서도 데이터를 볼 수 있고 데이터를 전부 Paging한 경우 Room에 데이터에 접근 할 수 있다.


### Result
https://github.com/YuYangWoo/InstagramFeedPreview/assets/59405161/45495327-e70b-4811-ae8b-afa2c45b7e48

